### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,19 @@ Please check the [CMake build instructions](cmake/README.md).
   cmake --build build --config Release --target install -v -- DESTDIR=install
   ```
 
+- Installing cpu_features(vcpkg)
+  
+  You can download and install cpu_features using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+  ```sh
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install cpu_features
+  ```
+  
+  The cpu_features port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 <a name="bindings"></a>
 ## Community bindings
 


### PR DESCRIPTION
`cpu_features` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `cpu_features` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build cpu_features, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cpu_features/portfile.cmake). We try to keep the library maintained as close as possible to the original library.